### PR TITLE
Add Datastore component to store user's emails

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -27,6 +27,20 @@
       <version>4.0.1</version>
     </dependency>
 
+    <!-- Jsoup -->
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.8.3</version>
+    </dependency>
+
+    <!-- Datastore -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>1.104.0</version>
+    </dependency>
+
     <!-- Gson -->
     <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/portfolio/src/main/java/com/google/sps/servlets/SubmitEmailServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/SubmitEmailServlet.java
@@ -5,6 +5,13 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.KeyFactory;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
 
 /**
  * Responds to a request consisting of a user's email
@@ -19,12 +26,26 @@ public class SubmitEmailServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
     // Get the value entered in the form.
-    String email = request.getParameter("email-address");
+    // String email = request.getParameter("email-address");
+
+    String email = Jsoup.clean(request.getParameter("email-address"), Whitelist.none());
+    long timestamp = System.currentTimeMillis();
+
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+    KeyFactory keyFactory = datastore.newKeyFactory().setKind("Email");
+    FullEntity taskEntity =
+        Entity.newBuilder(keyFactory.newKey())
+            .set("title", email)
+            .set("timestamp", timestamp)
+            .build();
+    datastore.put(taskEntity);
+
+    response.sendRedirect("/index.html");
 
     // Print the value so you can see it in the server logs.
     System.out.println("User's email: " + email);
 
     // Write the value to the response so the user can see it.
-    response.getWriter().println("Thank you for your response! I will be reaching out to you soon");
+    //response.getWriter().println("Thank you for your response! I will be reaching out to you soon");
   }
 }


### PR DESCRIPTION
I followed the Datastore tutorial in Week 3 to connect my portfolio to Datastore. Now, when user's submit their email to my website, their email and a timestamp will be stored in Datastore instead of having to refer to the logs. I used the KeyFactory to build each entity, that would then be put into Datastore. I tested my website using the Web Preview button in Cloud Shell. I originally ran into some errors, but realized that I just needed to run a command to have Datastore up and running with my portfolio's Project ID.